### PR TITLE
Added `volatile` volume option

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"errors"
-	"github.com/docker/go-plugins-helpers/volume"
 	"os"
 	"regexp"
 	"strings"
 	"syscall"
+
+	"github.com/docker/go-plugins-helpers/volume"
 )
 
 // The base directory of docker-on-top, where all the overlays' internals will be saved


### PR DESCRIPTION
Implement volatile volumes.

A volatile volume loses the changes made in it as soon as it is unmounted from the last container that was using it. It continues to exist but on the next mount it looks like a fresh docker-on-top volume, that is, it's initial contents is identical to the base dir's contents.

Fixes #3