### PR TITLE
Rewrite volume storage, refactor some of the old code

### DIFF
--- a/dockerOnTop.go
+++ b/dockerOnTop.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// internalError wraps the given error in the "docker-on-top internal error: #{help}: #{err}" message. It is useful for
+// when the error is reported to the docker daemon so that the end user knows it's not their mistake but an internal
+// error.
+func internalError(help string, err error) error {
+	// Maybe make a custom error type instead?
+	return fmt.Errorf("docker-on-top internal error: %s: %w", help, err)
+}
+
+// DockerOnTop contains internal data of the docker-on-top volume driver and implements the `volume.Driver` interface
+// (from docker's go-plugins-helpers)
+type DockerOnTop struct {
+	// dotRootDir is the base directory of docker-on-top, where all the internal information is stored.
+	// Must contain a trailing slash.
+	dotRootDir string
+}
+
+// NewDockerOnTop creates a new `DockerOnTop` object using the given directory as the dot root directory. If it doesn't
+// exist, it is created as in `mkdir -p`. On error, it is returned and `DockerOnTop` is not created.
+func NewDockerOnTop(dotRootDir string) (*DockerOnTop, error) {
+	if len(dotRootDir) == 0 {
+		return nil, errors.New("`dotRootDir` cannot be empty")
+	}
+
+	if dotRootDir[len(dotRootDir)-1] != '/' {
+		dotRootDir += "/"
+	}
+
+	err := os.MkdirAll(dotRootDir, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DockerOnTop{dotRootDir: dotRootDir}, nil
+}
+
+// MustNewDockerOnTop behaves as `NewDockerOnTop` but panics in case of an error
+func MustNewDockerOnTop(baseDir string) *DockerOnTop {
+	driver, err := NewDockerOnTop(baseDir)
+	if err != nil {
+		panic(fmt.Errorf("failed to MkdirAll %s: %v", baseDir, err))
+	}
+	return driver
+}

--- a/driver.go
+++ b/driver.go
@@ -154,7 +154,7 @@ func (d *Driver) List() (*volume.ListResponse, error) {
 	for volumeName := range d.volumes {
 		response.Volumes = append(response.Volumes, &volume.Volume{Name: volumeName})
 	}
-	log.Debugf("Volumes listed: %s", response.Volumes)
+	log.Debugf("Volumes listed: %v", response.Volumes)
 	return &response, nil
 }
 
@@ -248,12 +248,11 @@ func (d *Driver) Mount(request *volume.MountRequest) (*volume.MountResponse, err
 	}
 
 	fstype := "overlay"
-	// TODO: escape commas in directory names
 	data := "lowerdir=" + lowerdir + ",upperdir=" + upperdir + ",workdir=" + workdir
 
 	err = syscall.Mount("docker-on-top_"+request.Name, mountpoint, fstype, 0, data)
 	if err != nil {
-		log.Errorf("Failed to mount %s: %v", request.Name, err)
+		log.Errorf("Failed to mount volume %s: %v", request.Name, err)
 		return nil, err
 	}
 

--- a/driver.go
+++ b/driver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -13,6 +14,17 @@ import (
 // The base directory of docker-on-top, where all the overlays' internals will be saved
 const dotBaseDir string = "/var/lib/docker-on-top/"
 
+func init() {
+	err := os.MkdirAll(dotBaseDir, os.ModePerm)
+	if err != nil {
+		log.Fatalf("Failed to MkdirAll dotBaseDir: %v", dotBaseDir, err)
+	}
+}
+
+func internalError(help string, err error) error {
+	return fmt.Errorf("docker-on-top internal error: %s: %w", help, err)
+}
+
 type VolumeData struct {
 	Name        string
 	BaseDirPath string
@@ -20,21 +32,36 @@ type VolumeData struct {
 	MountsCount int // The number of containers using the volume at the moment
 }
 
+/*
+Here is how the internal volume management works.
+
+Each existing volume has a corresponding "main directory" named the same as the volume name located at the `dotBaseDir`
+directory. For example, if a volume with name FooBar is created, the main directory
+corresponding to it is /var/lib/docker-on-top/FooBar/ (as long as `dotBaseDir` is /var/lib/docker-on-top/).
+A volume's main directory is created when the volume is created and removed when the volume is removed.
+
+Inside a volume's main directory there are the following files/directories:
+	- upper/  - the upperdir of an overlay mount. Exists always. For volatile mounts, recreated from scratch on every
+		mount (unless the volume is already mounted to another container). On unmount no special action occurs.
+	- workdir/  - the workdir of an overlay mount. Exists only when the volume is mounted.
+	- mountpoint/  - the directory where the overlay is to be mounted to. Exists only when the volume is mounted.
+*/
+
 // Driver contains internal data for the docker-on-top volume driver. It does not export any fields
 type Driver struct {
 	volumes map[string]VolumeData
 }
 
-func (d *Driver) getMountpoint(volumeName string) string {
-	return dotBaseDir + d.volumes[volumeName].Name + "/mountpoint"
+func (d *Driver) mountpoint(volumeName string) string {
+	return dotBaseDir + volumeName + "/mountpoint"
 }
 
-func (d *Driver) getUpperdir(volumeName string) string {
-	return dotBaseDir + d.volumes[volumeName].Name + "/upper"
+func (d *Driver) upperdir(volumeName string) string {
+	return dotBaseDir + volumeName + "/upper"
 }
 
-func (d *Driver) getWorkdir(volumeName string) string {
-	return dotBaseDir + d.volumes[volumeName].Name + "/workdir"
+func (d *Driver) workdir(volumeName string) string {
+	return dotBaseDir + volumeName + "/workdir"
 }
 
 // This regex is based on the error message from docker daemon when requested to create a volume with invalid name
@@ -96,6 +123,26 @@ func (d *Driver) Create(request *volume.CreateRequest) error {
 		return errors.New("option `volatile` must be either 'true', 'false', 'yes', or 'no'")
 	}
 
+	if err := os.Mkdir(dotBaseDir+request.Name, os.ModePerm); err != nil {
+		if os.IsExist(err) {
+			log.Debug("Volume's main directory already exists. New volume not created")
+			return errors.New("volume already exists")
+		}
+		// Some other error - not expected
+		log.Errorf("Failed to Mkdir main directory: %v. Volume not created", err)
+		return internalError("failed to Mkdir volume main directory", err)
+	}
+
+	// Try to create upperdir. On failure, revert the creation of the volume main directory
+	if err := os.Mkdir(d.upperdir(request.Name), os.ModePerm); err != nil {
+		log.Errorf("Failed to Mkdir %s: %v. Removing the volume", request.Name, err)
+		cleanupErr := os.RemoveAll(dotBaseDir + request.Name)
+		if cleanupErr != nil {
+			log.Errorf("Failed to RemoveAll main directory: %v", dotBaseDir+request.Name, cleanupErr)
+		}
+		return internalError("failed to Mkdir upperdir", err)
+	}
+
 	d.volumes[request.Name] = VolumeData{Name: request.Name, BaseDirPath: baseDir, Volatile: volatile, MountsCount: 0}
 	return nil
 }
@@ -126,10 +173,11 @@ func (d *Driver) Get(request *volume.GetRequest) (*volume.GetResponse, error) {
 func (d *Driver) Remove(request *volume.RemoveRequest) error {
 	log.Debugf("Request Remove: Name=%s. It will succeed regardless of the presence of the volume", request.Name)
 	if _, ok := d.volumes[request.Name]; ok {
-		// Expecting the volume to have been unmounted by this moment
+		// Expecting the volume to have been unmounted by this moment. If it isn't, the error will be reported
 		err := os.RemoveAll(dotBaseDir + request.Name)
 		if err != nil {
-			return err
+			log.Errorf("Failed to RemoveAll main directory: %v", err)
+			return internalError("failed to RemoveAll volume main directory", err)
 		}
 	}
 	delete(d.volumes, request.Name)
@@ -138,7 +186,7 @@ func (d *Driver) Remove(request *volume.RemoveRequest) error {
 
 func (d *Driver) Path(request *volume.PathRequest) (*volume.PathResponse, error) {
 	log.Debugf("Request Path: Name=%s", request.Name)
-	return &volume.PathResponse{Mountpoint: d.getMountpoint(request.Name)}, nil
+	return &volume.PathResponse{Mountpoint: d.mountpoint(request.Name)}, nil
 }
 
 func (d *Driver) Mount(request *volume.MountRequest) (*volume.MountResponse, error) {
@@ -146,7 +194,7 @@ func (d *Driver) Mount(request *volume.MountRequest) (*volume.MountResponse, err
 
 	thisVol := d.volumes[request.Name] // Assuming the volume exists, as the docker daemon was supposed to check that
 
-	mountpoint := d.getMountpoint(request.Name)
+	mountpoint := d.mountpoint(request.Name)
 	response := volume.MountResponse{Mountpoint: mountpoint}
 
 	if thisVol.MountsCount > 0 {
@@ -159,15 +207,43 @@ func (d *Driver) Mount(request *volume.MountRequest) (*volume.MountResponse, err
 	}
 
 	lowerdir := d.volumes[request.Name].BaseDirPath
-	upperdir := d.getUpperdir(request.Name)
-	workdir := d.getWorkdir(request.Name)
+	upperdir := d.upperdir(request.Name)
+	workdir := d.workdir(request.Name)
 
-	for _, dir := range []string{lowerdir, upperdir, workdir, mountpoint} {
-		// TODO: create workdir with 000 permission
-		err := os.MkdirAll(dir, os.ModePerm)
+	err1 := os.Mkdir(mountpoint, os.ModePerm)
+	err2 := os.Mkdir(workdir, os.ModePerm)
+	err := errors.Join(err1, err2)
+	if err != nil {
+		log.Errorf("Failed to Mkdir mountpoint, workdir: %v, %v", err1, err2)
+
+		// Attempt to cleanup
+		if err1 == nil {
+			cleanupErr := os.Remove(mountpoint)
+			if cleanupErr != nil {
+				log.Errorf("Failed to cleanup mountpoint: %v", cleanupErr)
+			}
+		}
+		if err2 == nil {
+			cleanupErr := os.Remove(workdir)
+			if cleanupErr != nil {
+				log.Errorf("Failed to cleanup workdir: %v", cleanupErr)
+			}
+		}
+
+		return nil, internalError("failed to prepare internal directories", err)
+	}
+
+	// For volatile volume, discard previous changes
+	if thisVol.Volatile {
+		err := os.RemoveAll(upperdir)
 		if err != nil {
-			log.Errorf("Failed to create %s: %v", dir, err)
-			return nil, err
+			log.Errorf("Failed to RemoveAll upperdir (for volatile): %v", err)
+			return nil, internalError("failed to discard previous changes", err)
+		}
+		err = os.Mkdir(upperdir, os.ModePerm)
+		if err != nil {
+			log.Errorf("Failed to Mkdir upperdir (for volatile): %v", err)
+			return nil, internalError("failed to recreate upperdir", err)
 		}
 	}
 
@@ -175,7 +251,7 @@ func (d *Driver) Mount(request *volume.MountRequest) (*volume.MountResponse, err
 	// TODO: escape commas in directory names
 	data := "lowerdir=" + lowerdir + ",upperdir=" + upperdir + ",workdir=" + workdir
 
-	err := syscall.Mount("docker-on-top_"+request.Name, mountpoint, fstype, 0, data)
+	err = syscall.Mount("docker-on-top_"+request.Name, mountpoint, fstype, 0, data)
 	if err != nil {
 		log.Errorf("Failed to mount %s: %v", request.Name, err)
 		return nil, err
@@ -199,28 +275,27 @@ func (d *Driver) Unmount(request *volume.UnmountRequest) error {
 		return nil
 	}
 
-	err := syscall.Unmount(d.getMountpoint(request.Name), 0)
+	err := syscall.Unmount(d.mountpoint(request.Name), 0)
 	if err != nil {
 		log.Errorf("Failed to unmount %s: %v", request.Name, err)
 		return err
 	}
 
-	// For volatile volume, discard changes on last unmount
-	if thisVol.Volatile {
-		err1 := os.RemoveAll(d.getUpperdir(request.Name))
-		err2 := os.RemoveAll(d.getWorkdir(request.Name))
-		err = errors.Join(err1, err2)
-		if err != nil {
-			log.Errorf("Failed to remove upperdir,workdir for the volatile volume %s: %v", request.Name, err)
-		}
+	err1 := os.Remove(d.mountpoint(request.Name))
+	err2 := os.RemoveAll(d.workdir(request.Name))
+	err = errors.Join(err1, err2)
+	if err != nil {
+		log.Errorf("Cleanup of %s failed. Errors for mountpoint, workdir: %v, %v",
+			request.Name, err1, err2)
+		// Don't return yet. The error will be returned later
 	}
 
-	// Regardless of error with volatile cleanup, decrement the counter, as it tracks the number of active _mounts_,
+	// Regardless of whether cleanup succeeded, decrement the counter, as it tracks the number of active _mounts_,
 	// and the unmount system call was successful.
 	thisVol.MountsCount--
 	d.volumes[request.Name] = thisVol
 
-	// Report an error during volatility cleanup, if any, but most likely will just be `nil`
+	// Report an error during cleanup, if any, but most likely will just be `nil`
 	return err
 }
 

--- a/lockedFile.go
+++ b/lockedFile.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+type lockedFile struct {
+	*os.File
+}
+
+func (lf *lockedFile) Open(path string) error {
+	var err error
+	lf.File, err = os.Open(path)
+	if err != nil {
+		log.Errorf("Failed to Open: %v", err)
+		return internalError("failed to Open inside lockedFile", err)
+	}
+	err = syscall.Flock(int(lf.File.Fd()), syscall.LOCK_EX)
+	if err != nil {
+		// `syscall.Flock` operates on file descriptor, so the error won't contain the file path, thus adding it manually
+		log.Errorf("Failed to get exclusive lock on %s: %v", lf.File.Name(), err)
+		return internalError("failed to get exclusive Flock", err)
+	}
+	return nil
+}
+
+func (lf *lockedFile) Close() error {
+	defer lf.File.Close()
+	err := syscall.Flock(int(lf.File.Fd()), syscall.LOCK_UN)
+	if err != nil {
+		log.Criticalf("Failed to release lock on %s: %v", lf.File.Name(), err)
+		return err
+	}
+	return nil
+}

--- a/lockedFile.go
+++ b/lockedFile.go
@@ -5,13 +5,13 @@ import (
 	"syscall"
 )
 
-// lockedFile is a wrapper around `os.File` which overrides the `Open` and `Close` methods so that the file being
-// accessed is exclusively locked (via `flock(..., LOCK_EX)`).
+// lockedFile is a wrapper around `os.File` that adds `.Open()` and overrides `.Close()` methods so that the
+// underlying file is exclusively locked (via `flock(..., LOCK_EX)`) when accessed.
 type lockedFile struct {
 	*os.File
 }
 
-// Open opens the file as in `os.Open` and then lock the file in exclusive mode via `flock(..., LOCK_EX)`,
+// Open opens the file as in `os.Open` and locks the file in exclusive mode via `flock(..., LOCK_EX)`,
 // possibly blocking.
 //
 // If an error occurs in either step, it is reported and the internals are cleaned up (i.e. no need for the caller to
@@ -26,14 +26,15 @@ func (lf *lockedFile) Open(path string) error {
 	err = syscall.Flock(int(lf.File.Fd()), syscall.LOCK_EX)
 	if err != nil {
 		log.Errorf("Failed to get exclusive lock on %s: %v", lf.File.Name(), err)
-		// `syscall.Flock` operates on file descriptor, so the error won't contain the file path, thus adding it manually
 		lf.File.Close() // An error is going to be returned, so the caller won't call `.Close()`
 		return internalError("failed to get exclusive Flock", err)
 	}
 	return nil
 }
 
-// Close releases the lock on the underlying file and closes the file using its original `.Close()`
+// Close releases the lock on the underlying file and closes the file using its original `.Close()`.
+// If an error occurs when releasing the lock, it is logged and returned; the error from the original
+// `.Close()` is ignored.
 func (lf *lockedFile) Close() error {
 	defer lf.File.Close()
 	err := syscall.Flock(int(lf.File.Fd()), syscall.LOCK_UN)

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"os"
+
 	"github.com/docker/go-plugins-helpers/volume"
 	"github.com/op/go-logging"
-	"os"
 )
 
 func initLogger() *logging.Logger {

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 func initLogger() *logging.Logger {
 	// Define the log format
 	logFormat := logging.MustStringFormatter(
-		"%{color}%{time:2006-01-02 15:04:05.000} ▶ %{level:.4s} %{message} (in %{shortfunc})",
+		"%{color:reset}%{color}%{time:2006-01-02 15:04:05.000} ▶ %{level:.4s} %{message} [in %{shortfunc}]",
 	)
 
 	// Create a log backend that writes to standard error
@@ -32,10 +32,12 @@ func initLogger() *logging.Logger {
 var log *logging.Logger = initLogger()
 
 func main() {
-	log.Info("Hello there!")
+	dotRootDir := "/var/lib/docker-on-top/"
+	socketPath := "/run/docker/plugins/docker-on-top.sock"
 
-	handler := volume.NewHandler(MustNewDockerOnTop("/var/lib/docker-on-top/"))
-	log.Info(handler.ServeUnix("/run/docker/plugins/docker-on-top.sock", 0))
+	handler := volume.NewHandler(MustNewDockerOnTop(dotRootDir))
+	log.Infof("Serving at %s", socketPath)
+	log.Critical(handler.ServeUnix(socketPath, 0))
 
 	// TODO: in case of abrupt termination, delete the socket file
 }

--- a/main.go
+++ b/main.go
@@ -36,9 +36,7 @@ func main() {
 
 	log.Info("Hello there!")
 
-	handler := volume.NewHandler(&Driver{
-		volumes: map[string]VolumeData{},
-	})
+	handler := volume.NewHandler(MustNewDriver("/var/lib/docker-on-top/"))
 	log.Info(handler.ServeUnix("/run/docker/plugins/docker-on-top.sock", 0))
 
 	// TODO: in case of abrupt termination, delete the socket file

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	log.Info("Hello there!")
 
-	handler := volume.NewHandler(MustNewDriver("/var/lib/docker-on-top/"))
+	handler := volume.NewHandler(MustNewDockerOnTop("/var/lib/docker-on-top/"))
 	log.Info(handler.ServeUnix("/run/docker/plugins/docker-on-top.sock", 0))
 
 	// TODO: in case of abrupt termination, delete the socket file

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ func initLogger() *logging.Logger {
 var log *logging.Logger = initLogger()
 
 func main() {
+	// TODO: cleanup active mounts before starting
+
 	log.Info("Hello there!")
 
 	handler := volume.NewHandler(&Driver{

--- a/main.go
+++ b/main.go
@@ -32,8 +32,6 @@ func initLogger() *logging.Logger {
 var log *logging.Logger = initLogger()
 
 func main() {
-	// TODO: cleanup active mounts before starting
-
 	log.Info("Hello there!")
 
 	handler := volume.NewHandler(MustNewDockerOnTop("/var/lib/docker-on-top/"))

--- a/volumeInfo.go
+++ b/volumeInfo.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type VolumeInfo struct {
+	BaseDirPath string
+	Volatile    bool
+}
+
+func (d *DockerOnTop) metadatajson(volumeName string) string {
+	return d.dotRootDir + volumeName + "/metadata.json"
+}
+
+func (d *DockerOnTop) getVolumeInfo(volumeName string) (VolumeInfo, error) {
+	var vol VolumeInfo
+
+	payload, err := os.ReadFile(d.metadatajson(volumeName))
+	if err == nil {
+		err = json.Unmarshal(payload, &vol)
+	}
+
+	return vol, err
+}
+
+func (d *DockerOnTop) writeVolumeInfo(volumeName string, vol VolumeInfo) error {
+	payload, err := json.Marshal(vol)
+
+	if err == nil {
+		err = os.WriteFile(d.metadatajson(volumeName), payload, 0o666)
+	}
+
+	return err
+}

--- a/volumeTreeManagement.go
+++ b/volumeTreeManagement.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+/*
+Here is how the internal volume management works.
+
+Each existing volume has a corresponding "main directory" named the same as the volume name and located inside the
+"dot root directory". For example, if the dot root directory is /var/lib/docker-on-top/ and a volume with name FooBar is
+created, that volume's main directory is /var/lib/docker-on-top/FooBar/
+The volume's main directory is created when a volume is created and removed (together with *all* of its contents)
+when the volume is removed.
+
+Inside a volume's main directory there are the following files/directories:
+    - metadata.json  - stores the volume's metadata, which comprises the options it was created with.
+	- activemounts/  - stores information about containers currently using the volume. Each file in it corresponds to
+		a container, the name of the file container+mount ID (received from the docker daemon).
+		On mount/unmount operations, an exclusive lock (via `flock`) is taken on this directory _for the whole process_
+		of mounting/unmounting.
+	- upper/  - the upperdir of an overlay mount. Exists always. For volatile mounts, recreated from scratch on every
+		mount (unless the volume is already mounted to another container). On unmount no special action occurs.
+	- workdir/  - the workdir of an overlay mount. Exists only when the volume is mounted.
+	- mountpoint/  - the directory where the overlay is to be mounted to. Exists only when the volume is mounted.
+*/
+
+func (d *DockerOnTop) activemountsdir(volumeName string) string {
+	return d.dotRootDir + volumeName + "/activemounts/"
+}
+
+func (d *DockerOnTop) upperdir(volumeName string) string {
+	return d.dotRootDir + volumeName + "/upper/"
+}
+
+func (d *DockerOnTop) workdir(volumeName string) string {
+	return d.dotRootDir + volumeName + "/workdir/"
+}
+
+func (d *DockerOnTop) mountpointdir(volumeName string) string {
+	return d.dotRootDir + volumeName + "/mountpoint/"
+}
+
+// volumeTreeCreate creates a directory tree for the specified volume (but not metadata.json).
+//
+// If errors occur, they are logged and the returned error is wrapped with `internalError`, except when volume already
+// exists. In that case, nothing is logged and `os.ErrExist` is returned (without being wrapped).
+func (d *DockerOnTop) volumeTreeCreate(volumeName string) error {
+	if err := os.Mkdir(d.dotRootDir+volumeName, os.ModePerm); err != nil {
+		if os.IsExist(err) {
+			return err
+		} else {
+			log.Errorf("Failed to Mkdir main directory: %v", err)
+			return internalError("failed to Mkdir volume main directory", err)
+		}
+	}
+
+	// Try to create internal directories. On failure, revert the creation of the volume main directory
+	for _, dir := range []string{d.upperdir(volumeName), d.activemountsdir(volumeName)} {
+		if err := os.Mkdir(dir, os.ModePerm); err != nil {
+			log.Errorf("Failed to Mkdir internal directory: %v. Aborting volume creation (attempting "+
+				"to destroy the volume's tree)", volumeName, err)
+			_ = d.volumeTreeDestroy(volumeName) // The errors are logged, if any
+			return internalError("failed to Mkdir internal directories", err)
+		}
+	}
+
+	return nil
+}
+
+// volumeTreeDestroy destroys the directory tree for the specified volume, **recursively removing everything** inside
+// the volume's main directory, including any files/directories not created by the plugin, if any.
+//
+// In errors occur, they are logged and the returned error is wrapped with `internalError`.
+// Note that if the volume doesn't exist, the function call is considered successful (`nil` is returned).
+func (d *DockerOnTop) volumeTreeDestroy(volumeName string) error {
+	err := os.RemoveAll(d.dotRootDir + volumeName)
+	if err != nil {
+		log.Errorf("Failed to RemoveAll main directory: %v", err)
+		return internalError("failed to RemoveAll volume main directory", err)
+	}
+	return nil
+}
+
+// volumeTreePreMount creates the directories in the volume's directory tree that should only exist when the volume
+// is mounted.
+//
+// If either the mountpoint or the workdir directories exist, it is logged as a warning but not considered an error.
+//
+// If errors occur, they are logged and the returned error is wrapped with `internalError`.
+func (d *DockerOnTop) volumeTreePreMount(volumeName string, discardUpper bool) error {
+	mountpoint := d.mountpointdir(volumeName)
+	workdir := d.workdir(volumeName)
+
+	err1 := os.Mkdir(mountpoint, os.ModePerm)
+	if os.IsExist(err1) {
+		log.Warningf("Mountpoint of %s already exists. It usually means that the overlay is already mounted "+
+			"but the plugin failed to detect it...", volumeName)
+	}
+	err2 := os.Mkdir(workdir, os.ModePerm)
+	if os.IsExist(err2) {
+		log.Warningf("Workdir of %s already exists. It usually means that the overlay is already mounted but "+
+			"the plugin failed to detect it...", volumeName)
+	}
+	err := errors.Join(err1, err2)
+	if (err1 != nil && !os.IsExist(err1)) || (err2 != nil && !os.IsExist(err2)) {
+		log.Errorf("Failed to Mkdir mountpoint, workdir: %v, %v", err1, err2)
+
+		// Attempt to clean up. Only remove the directories that we created moments ago
+
+		if err1 == nil {
+			cleanupErr := os.Remove(mountpoint)
+			if cleanupErr != nil {
+				log.Errorf("Failed to cleanup mountpoint: %v", cleanupErr)
+			}
+		}
+		if err2 == nil {
+			cleanupErr := os.Remove(workdir)
+			if cleanupErr != nil {
+				log.Errorf("Failed to cleanup workdir: %v", cleanupErr)
+			}
+		}
+
+		return internalError("failed to prepare internal directories", err)
+	}
+
+	// For volatile volume, discard previous changes
+	if discardUpper {
+		upperdir := d.upperdir(volumeName)
+
+		err = os.RemoveAll(upperdir)
+		if err != nil {
+			log.Errorf("Failed to RemoveAll upperdir (for volatile): %v", err)
+			return internalError("failed to discard previous changes", err)
+		}
+		err = os.Mkdir(upperdir, os.ModePerm)
+		if err != nil {
+			log.Errorf("Failed to Mkdir upperdir (for volatile): %v", err)
+			return internalError("failed to create upperdir after discarding changes", err)
+		}
+	}
+
+	return nil
+}
+
+// volumeTreePostUnmount removes the directories in the volume's directory tree that should only exist when the volume
+// is mounted.
+//
+// It removes the mountpoint directory (non-recursively: must be empty) and the workdir directory (recursively: all of
+// its contents is deleted). No action is taken regarding upperdir, regardless of the volume's volatility.
+//
+// Removal of both directories is attempted regardless of errors with the other directory. Errors, if any, are logged,
+// combined with `errors.Join` and returned (wrapped with `internalError`).
+//
+// Note: for technical reasons, the absense of the workdir directory is not considered an error.
+func (d *DockerOnTop) volumeTreePostUnmount(volumeName string) error {
+	err1 := os.Remove(d.mountpointdir(volumeName))
+	err2 := os.RemoveAll(d.workdir(volumeName))
+	err := errors.Join(err1, err2)
+	if err != nil {
+		log.Errorf("Cleanup of %s failed. Errors for mountpoint, workdir: %v, %v", volumeName, err1, err2)
+		return internalError("failed to cleanup on unmount", err)
+	}
+	return nil
+}


### PR DESCRIPTION
The following features are introduced by this PR:
- Volumes list is preserved on plugin restart (fixes #7)
- Everywhere outside the constructor (`NewDockerOnTop`) all the volumes and their metadata is accessed in a thread-safe manner, synchronized via filesystem access (there's a new requirement: the `/var/lib/docker-on-top/` is located on a filesystem that supports the `flock` system call) (fixes #15)
- When started, the plugin checks all the existing volumes for unclean unmount (e.g. in case of reboot that didn't let the docker daemon properly cleanup) and attempts to fix it. There are some cases it is unable to detect (e.g. when it was down at the moment some container exited and for a long enough time after that) but the behavior is still better than before, and a reboot always fixes everything